### PR TITLE
Remove hardcoded org1msp with %ORGMSP_ID%

### DIFF
--- a/values.yaml.base
+++ b/values.yaml.base
@@ -41,7 +41,7 @@ persistence:
 ## Peer configuration options    #
 ##################################
 peer:
-  mspID: org1msp
+  mspID: %ORGMSP_ID%
   # Type of database ("goleveldb" or "CouchDB"):
   databaseType: goleveldb
   tls:


### PR DESCRIPTION
Finally found the root cause for this message "Error: can't read the block: &{FORBIDDEN}". This is because in values.yaml, it has the hardcoded org1msp each time deploy.sh is being executed. Although orderer TLS CA cert is correct, but mspID is wrong. Therefore order prompted back FORBIDDEN message.